### PR TITLE
Added MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.txt
+
+recursive-include docs *
+recursive-include iservice *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include *.txt
 
 recursive-include docs *
-recursive-include iservice *
+recursive-include iservices *

--- a/README.txt
+++ b/README.txt
@@ -15,6 +15,10 @@ Changelog
 
 Please, see README.txt instead.
 
+0.4.1 (unreleased)
+------------------
+- Added MANIFEST.in so all files included when creating an egg from this package
+
 0.4 (unreleased)
 ..................
 - Plone 4.1 compatibility

--- a/README.txt
+++ b/README.txt
@@ -17,7 +17,7 @@ Please, see README.txt instead.
 
 0.4.1 (unreleased)
 ------------------
-- Added MANIFEST.in so all files included when creating an egg from this package
+- Added MANIFEST.in so all files included when creating an egg from this package [kcleong]
 
 0.4 (unreleased)
 ..................

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '0.3'
+version = '0.4.1'
 
 setup(name='iservices.rssdocument',
       version=version,


### PR DESCRIPTION
I tried installing this module from pypi (v 0.4) in my buildout, but it failed because certain files where missing in the egg. 

This is fixed my adding the MANIFEST.in file, which tells to include all eggs when you're creating the egg.

Cheers,

Kim Chee
